### PR TITLE
Replaced URLEncoder with guava.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
             <groupId>commons-daemon</groupId>
             <artifactId>commons-daemon</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>20.0</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/BagStoreComponent.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.authinfo.components
 
 import java.net.{ URI, URL, URLEncoder }
+import java.nio.file.Paths
 import java.util.UUID
 
 import nl.knaw.dans.easy.authinfo.{ BagInfo, HttpStatusException }
@@ -23,6 +24,7 @@ import nl.knaw.dans.easy.authinfo.{ BagInfo, HttpStatusException }
 import scala.util.{ Failure, Success, Try }
 import scala.xml.{ Elem, XML }
 import scalaj.http.Http
+import nl.knaw.dans.easy.authinfo.escapePath
 
 trait BagStoreComponent {
 
@@ -58,7 +60,7 @@ trait BagStoreComponent {
     }
 
     private def toURL(bagId: UUID, path: String): Try[URL] = Try {
-      val f = URLEncoder.encode(path, "UTF8")
+      val f = escapePath(Paths.get(path))
       baseUri.resolve(s"bags/$bagId/$f").toURL
     }
   }

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/package.scala
@@ -15,8 +15,13 @@
  */
 package nl.knaw.dans.easy
 
+import java.nio.file.Path
+
+import com.google.common.net.UrlEscapers
+
 import scala.util.{ Failure, Success, Try }
 import scalaj.http.HttpResponse
+import collection.JavaConverters._
 
 package object authinfo {
 
@@ -24,6 +29,13 @@ package object authinfo {
 
   case class HttpStatusException(msg: String, response: HttpResponse[String])
     extends Exception(s"$msg - ${ response.statusLine }, details: ${ response.body }")
+
+  private val pathEscaper = UrlEscapers.urlPathSegmentEscaper()
+
+  def escapePath(path: Path): String = {
+    path.asScala.map(_.toString).map(pathEscaper.escape).mkString("/")
+  }
+
 
   implicit class TryExtensions2[T](val t: Try[T]) extends AnyVal {
     // TODO candidate for dans-scala-lib


### PR DESCRIPTION
Similar fix to the one done last week in `easy-download`. The percent-encoding done by URLEncoder is not the standard one that should be used for URLs. Also, do not encode the slashes in the path, only the path components.

@DANS-KNAW/easy 