### PR TITLE
EASY-2021 Corrigeer aanroepen van bag-store op nieuwe percent-encoding regels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.5.0</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.scalaj</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 
 import nl.knaw.dans.easy.authinfo.components.{ FileItem, FileRights }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.encode.PathEncoding
 import org.json4s.native.JsonMethods.{ pretty, render }
 
 import scala.util.{ Failure, Success, Try }
@@ -29,11 +30,11 @@ import scala.xml.{ Elem, Node }
 trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with ApplicationWiring {
 
   def rightsOf(bagId: UUID, bagRelativePath: Path): Try[Option[CachedAuthInfo]] = {
-    authCache.search(s"$bagId/$bagRelativePath") match {
+    authCache.search(s"$bagId/${bagRelativePath.escapePath}") match {
       case Success(Some(doc)) => Success(Some(CachedAuthInfo(FileItem.toJson(doc))))
       case Success(None) => fromBagStore(bagId, bagRelativePath)
       case Failure(t) =>
-        logger.warn(s"cache lookup failed for [$bagId/$bagRelativePath] ${ Option(t.getMessage).getOrElse("") }")
+        logger.warn(s"cache lookup failed for [$bagId/${bagRelativePath.escapePath}] ${ Option(t.getMessage).getOrElse("") }")
         fromBagStore(bagId, bagRelativePath)
     }
   }

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/BagStoreComponent.scala
@@ -19,7 +19,8 @@ import java.net.{ URI, URL }
 import java.nio.file.Paths
 import java.util.UUID
 
-import nl.knaw.dans.easy.authinfo.{ BagInfo, HttpStatusException, escapePath }
+import nl.knaw.dans.lib.encode.PathEncoding
+import nl.knaw.dans.easy.authinfo.{ BagInfo, HttpStatusException }
 
 import scala.util.{ Failure, Success, Try }
 import scala.xml.{ Elem, XML }
@@ -67,7 +68,7 @@ trait BagStoreComponent {
     }
 
     private def toURL(bagId: UUID, path: String): Try[URL] = Try {
-      val f = escapePath(Paths.get(path))
+      val f = Paths.get(path).escapePath
       baseUri.resolve(s"bags/$bagId/$f").toURL
     }
   }

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/package.scala
@@ -15,15 +15,11 @@
  */
 package nl.knaw.dans.easy
 
-import java.nio.file.Path
-
-import com.google.common.net.UrlEscapers
 import nl.knaw.dans.easy.authinfo.components.AuthCacheNotConfigured.CacheLiterals
 import org.apache.solr.client.solrj.response.UpdateResponse
 import org.apache.solr.common.util.NamedList
 import org.json4s.JsonAST.JValue
 
-import scala.collection.JavaConverters._
 import scala.util.Try
 import scalaj.http.HttpResponse
 
@@ -41,12 +37,6 @@ package object authinfo {
 
     // TODO candidate for dans-scala-lib
     def toOneLiner: String = s.split("\n").map(_.trim).mkString(" ")
-  }
-
-  private val pathEscaper = UrlEscapers.urlPathSegmentEscaper()
-
-  def escapePath(path: Path): String = {
-    path.asScala.map(_.toString).map(pathEscaper.escape).mkString("/")
   }
 
   case class HttpStatusException(msg: String, response: HttpResponse[String])


### PR DESCRIPTION
Fixes EASY-2021

#### When applied it
* replaces calls to `Guava UrlEscapers` methods with calls to `dans-scala-lib `encoding methods
  (which in turn make use of `Guava PercentEscaper`)

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-bag-store                | [DANS-KNAW/easy-bag-store/pull/91] | ..
easy-download                | [DANS-KNAW/easy-download/pull/33] | ..
easy-ingest-flow             | [DANS-KNAW/easy-ingest-flow/pull/109] | ..
easy-solr4files-index      | [DANS-KNAW/easy-solr4files-index/pull/39] | ..
easy-validate-dans-bag | [DANS-KNAW/easy-validate-dans-bag/pull/57] | ..
