### PR TITLE
EASY-1919: easy-download returns 500 instead of 404 when invalid bag-id is provided

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -65,6 +65,7 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
   }
 
   private def fromBagStore(bagId: UUID, path: Path): Try[Option[CachedAuthInfo]] = {
+    logger.info(s"[$bagId] item for path $path not found in autCache, trying to retrieve item from bagStore")
     bagStore
       .loadFilesXML(bagId)
       .map(getFileNode(_, path))

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -30,6 +30,7 @@ import scala.xml.{ Elem, Node }
 trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with ApplicationWiring {
 
   def rightsOf(bagId: UUID, bagRelativePath: Path): Try[Option[CachedAuthInfo]] = {
+    logger.info(s"[$bagId] retrieving rightsOf item $bagRelativePath")
     authCache.search(s"$bagId/${bagRelativePath.escapePath}") match {
       case Success(Some(doc)) => Success(Some(CachedAuthInfo(FileItem.toJson(doc))))
       case Success(None) => fromBagStore(bagId, bagRelativePath)

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -59,7 +59,7 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
   }
 
   /** @param fullPath <UUID>/<bag-relative-path> */
-  private def extractUUID(fullPath: Path) = {
+  private def extractUUID(fullPath: Path): Try[UUID] = {
     Try(UUID.fromString(fullPath.getName(0).toString))
       .recoverWith { case t => Failure(new Exception(s"can't extract valid UUID from [$fullPath]", t)) }
   }
@@ -78,7 +78,7 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
       }
   }
 
-  private def collectInfo(bagId: UUID, path: Path, fileNode: Node) = {
+  private def collectInfo(bagId: UUID, path: Path, fileNode: Node): Try[FileItem] = {
     for {
       ddm <- bagStore.loadDDM(bagId)
       ddmProfile <- getTag(ddm, "profile", bagId)
@@ -94,7 +94,7 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
       .recoverWith { case _ => Failure(InvalidBagException(s"<ddm:$tag> not found in $bagId/dataset.xml")) }
   }
 
-  private def getDepositor(bagInfoMap: BagInfo, bagId: UUID) = {
+  private def getDepositor(bagInfoMap: BagInfo, bagId: UUID): Try[String] = {
     Try(bagInfoMap("EASY-User-Account"))
       .recoverWith { case _ => Failure(InvalidBagException(s"'EASY-User-Account' (case sensitive) not found in $bagId/bag-info.txt")) }
   }

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoServlet.scala
@@ -69,7 +69,7 @@ class EasyAuthInfoServlet(app: EasyAuthInfoApp) extends ScalatraServlet
         Ok(pretty(render(json)))
       case Success(None) => NotFound(s"$uuid/$path does not exist")
       case Failure(HttpStatusException(message, HttpResponse(_, SERVICE_UNAVAILABLE_503, _))) => ServiceUnavailable(message)
-      case Failure(BagDoesNotExistException(uuid: UUID)) => NotFound(s"$uuid does not exist")
+      case Failure(BagDoesNotExistException(uuid: UUID)) => NotFound(s"$uuid/$path does not exist")
       case Failure(t: InvalidBagException) =>
         logger.error(s"invalid bag: ${ t.getMessage }")
         InternalServerError("not expected exception")

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/BagStoreComponent.scala
@@ -20,12 +20,14 @@ import java.nio.file.Paths
 import java.util.UUID
 
 import nl.knaw.dans.lib.encode.PathEncoding
-import nl.knaw.dans.easy.authinfo.{ BagInfo, HttpStatusException }
+import nl.knaw.dans.easy.authinfo.{ BagDoesNotExistException, BagInfo, HttpStatusException }
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import scalaj.http.HttpResponse
 
 import scala.util.{ Failure, Success, Try }
 import scala.xml.{ Elem, XML }
 
-trait BagStoreComponent {
+trait BagStoreComponent extends DebugEnhancedLogging {
   this: HttpContext =>
 
   val bagStore: BagStore
@@ -33,15 +35,23 @@ trait BagStoreComponent {
   trait BagStore {
     val baseUri: URI
 
+    private val bagNotFoundMessageRegex = ".*Bag [0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12} does not exist in BagStore.*"
+
     def loadDDM(bagId: UUID): Try[Elem] = {
+      logger.info(s"[$bagId] retrieving ddm.xml")
       toURL(bagId, "metadata/dataset.xml").flatMap(loadXml)
     }
 
     def loadFilesXML(bagId: UUID): Try[Elem] = {
+      logger.info(s"[$bagId] retrieving files.xml")
       toURL(bagId, "metadata/files.xml").flatMap(loadXml)
+        .recoverWith {
+          case HttpStatusException(msg: String, response: HttpResponse[String]) if isBagDoesNotExistErrorMessage(msg, response.body) => Failure(BagDoesNotExistException(bagId))
+        }
     }
 
     def loadBagInfo(bagId: UUID): Try[BagInfo] = {
+      logger.info(s"[$bagId] retrieving bag-info.txt")
       toURL(bagId, "bag-info.txt").flatMap(loadBagInfo)
     }
 
@@ -71,5 +81,7 @@ trait BagStoreComponent {
       val escapedPath = Paths.get(path).escapePath
       baseUri.resolve(s"bags/$bagId/$escapedPath").toURL
     }
+
+    private def isBagDoesNotExistErrorMessage(message: String, body: String): Boolean = message.startsWith("Bag ") || body.matches(bagNotFoundMessageRegex)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/BagStoreComponent.scala
@@ -68,8 +68,8 @@ trait BagStoreComponent {
     }
 
     private def toURL(bagId: UUID, path: String): Try[URL] = Try {
-      val f = Paths.get(path).escapePath
-      baseUri.resolve(s"bags/$bagId/$f").toURL
+      val escapedPath = Paths.get(path).escapePath
+      baseUri.resolve(s"bags/$bagId/$escapedPath").toURL
     }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/BagStoreComponent.scala
@@ -35,7 +35,7 @@ trait BagStoreComponent extends DebugEnhancedLogging {
   trait BagStore {
     val baseUri: URI
 
-    private val bagNotFoundMessageRegex = ".*Bag [0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12} does not exist in BagStore.*"
+    private val bagNotFoundMessageRegex = ".*Bag [0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12} does not exist in BagStore.*"
 
     def loadDDM(bagId: UUID): Try[Elem] = {
       logger.info(s"[$bagId] retrieving ddm.xml")

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/FileItem.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/FileItem.scala
@@ -50,7 +50,7 @@ object FileItem {
     "easy_date_available" -> "dateAvailable"
   )
 
-  private def solr2jsonKey(key: String) = solr2JsonKeys.getOrElse(key, key)
+  private def solr2jsonKey(key: String): String = solr2JsonKeys.getOrElse(key, key)
 
   def toJson(solrDocument: SolrDocument): JsonAST.JObject = {
     val fieldValueMap = solrDocument.getFieldValueMap

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/package.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy
 
+import java.util.UUID
+
 import nl.knaw.dans.easy.authinfo.components.AuthCacheNotConfigured.CacheLiterals
 import org.apache.solr.client.solrj.response.UpdateResponse
 import org.apache.solr.common.util.NamedList
@@ -38,6 +40,9 @@ package object authinfo {
     // TODO candidate for dans-scala-lib
     def toOneLiner: String = s.split("\n").map(_.trim).mkString(" ")
   }
+
+  case class BagDoesNotExistException(uuid: UUID)
+    extends Exception(s"Bag $uuid does not exist")
 
   case class HttpStatusException(msg: String, response: HttpResponse[String])
     extends Exception(s"$msg - ${ response.statusLine }, details: ${ response.body }")

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/ServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/ServletSpec.scala
@@ -124,7 +124,7 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
   it should "report bag not found" in {
     expectsSolrDocIsNotInCache
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Failure(BagDoesNotExistException(randomUUID))
-    shouldReturn(NOT_FOUND_404, s"$randomUUID does not exist")
+    shouldReturn(NOT_FOUND_404, s"$randomUUID/some.file does not exist")
   }
 
   it should "report file not found" in {

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/ServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/ServletSpec.scala
@@ -127,6 +127,12 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
     shouldReturn(NOT_FOUND_404, s"$randomUUID does not exist")
   }
 
+  it should "report bag not found, also if the 'Bag <uuid> is not in the message part but in the body" in {
+    expectsSolrDocIsNotInCache
+    mockedBagStore.loadFilesXML _ expects randomUUID once() returning Failure(HttpStatusException(s"http://localhost", HttpResponse(s"Post bla bla bla 404, etc Bag $randomUUID does not exist in BagStore", 404, Map("Status" -> IndexedSeq("404")))))
+    shouldReturn(NOT_FOUND_404, s"$randomUUID does not exist")
+  }
+
   it should "report file not found" in {
     expectsSolrDocIsNotInCache
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Success(<files/>)

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/ServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/ServletSpec.scala
@@ -123,13 +123,7 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
 
   it should "report bag not found" in {
     expectsSolrDocIsNotInCache
-    mockedBagStore.loadFilesXML _ expects randomUUID once() returning httpException(s"Bag $randomUUID does not exist in BagStore")
-    shouldReturn(NOT_FOUND_404, s"$randomUUID does not exist")
-  }
-
-  it should "report bag not found, also if the 'Bag <uuid> is not in the message part but in the body" in {
-    expectsSolrDocIsNotInCache
-    mockedBagStore.loadFilesXML _ expects randomUUID once() returning Failure(HttpStatusException(s"http://localhost", HttpResponse(s"Post bla bla bla 404, etc Bag $randomUUID does not exist in BagStore", 404, Map("Status" -> IndexedSeq("404")))))
+    mockedBagStore.loadFilesXML _ expects randomUUID once() returning Failure(BagDoesNotExistException(randomUUID))
     shouldReturn(NOT_FOUND_404, s"$randomUUID does not exist")
   }
 


### PR DESCRIPTION
Fixes EASY-1919

#### When applied it will
* return 404 instead of 500 if bag is not found in

- [x]  discuss solution is optimal

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?


