### PR TITLE
EASY-2137: add configurable timeouts for calls to easy-bag-store

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -2,6 +2,8 @@ daemon.http.port=20170
 
 # terminating slash is required
 bag-store.url=http://localhost:20110/
+bag-store.connection-timeout-ms=600000
+bag-store.read-timeout-ms=600000
 
 # no terminating slash
 solr.url=http://localhost:8983/solr

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/ApplicationWiring.scala
@@ -38,6 +38,8 @@ trait ApplicationWiring extends BagStoreComponent with HttpContext with DebugEnh
 
   override val bagStore: BagStore = new BagStore {
     override val baseUri: URI = new URI(configuration.properties.getString("bag-store.url"))
+    override val connTimeout: Int = configuration.properties.getInt("bag-store.connection-timeout-ms")
+    override val readTimeout: Int = configuration.properties.getInt("bag-store.read-timeout-ms")
   }
 
   val authCache: AuthCacheNotConfigured = {

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/BagStoreComponent.scala
@@ -34,6 +34,8 @@ trait BagStoreComponent extends DebugEnhancedLogging {
 
   trait BagStore {
     val baseUri: URI
+    val connTimeout: Int
+    val readTimeout: Int
 
     private val bagNotFoundMessageRegex = ".*Bag [0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12} does not exist in BagStore.*"
 
@@ -57,7 +59,7 @@ trait BagStoreComponent extends DebugEnhancedLogging {
 
     private def loadXml(url: URL): Try[Elem] = {
       for {
-        response <- Try { Http(url.toString).asString }
+        response <- Try { Http(url.toString).timeout(connTimeout, readTimeout).asString }
         _ <- if (response.isSuccess) Success(())
              else Failure(HttpStatusException(url.toString, response))
       } yield XML.loadString(response.body)
@@ -65,7 +67,7 @@ trait BagStoreComponent extends DebugEnhancedLogging {
 
     private def loadBagInfo(url: URL): Try[BagInfo] = {
       for {
-        response <- Try { Http(url.toString).asString }
+        response <- Try { Http(url.toString).timeout(connTimeout, readTimeout).asString }
         _ <- if (response.isSuccess) Success(())
              else Failure(HttpStatusException(url.toString, response))
       } yield response

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -2,6 +2,8 @@ daemon.http.port=20170
 
 # terminating slash is required
 bag-store.url=http://test.dans.knaw.nl:20110/
+bag-store.connection-timeout-ms=600000
+bag-store.read-timeout-ms=600000
 
 # no terminating slash
 solr.url=http://test.dans.knaw.nl:8983/solr

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,12 +1,12 @@
 daemon.http.port=20170
 
 # terminating slash is required
-bag-store.url=http://test.dans.knaw.nl:20110/
-bag-store.connection-timeout-ms=600000
-bag-store.read-timeout-ms=600000
+bag-store.url=http://deasy.dans.knaw.nl:20110/
+bag-store.connection-timeout-ms=5000
+bag-store.read-timeout-ms=5000
 
 # no terminating slash
-solr.url=http://test.dans.knaw.nl:8983/solr
+solr.url=http://deasy.dans.knaw.nl:8983/solr
 solr.collection=authinfo
 #see also system properties for <autoCommit> and <AutoSoftCommit> in authinfo/solrconfig.xml
 solr.commitWithinMs=15000

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/TestSupportFixture.scala
@@ -63,8 +63,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
       override val bagStore: BagStore = mock[BagStore]
       override lazy val configuration: Configuration = new Configuration("", new PropertiesConfiguration() {
         addProperty("bag-store.url", "http://hostThatDoesNotExist:20110/")
-        addProperty("bag-store.connection-timeout-ms", "5000")
-        addProperty("bag-store.read-timeout-ms", "5000")
+        addProperty("bag-store.connection-timeout-ms", "1")
+        addProperty("bag-store.read-timeout-ms", "1")
         addProperty("solr.url", "http://hostThatDoesNotExist")
         addProperty("solr.collection", "authinfo")
       })

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/TestSupportFixture.scala
@@ -63,6 +63,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
       override val bagStore: BagStore = mock[BagStore]
       override lazy val configuration: Configuration = new Configuration("", new PropertiesConfiguration() {
         addProperty("bag-store.url", "http://hostThatDoesNotExist:20110/")
+        addProperty("bag-store.connection-timeout-ms", "600000")
+        addProperty("bag-store.read-timeout-ms", "600000")
         addProperty("solr.url", "http://hostThatDoesNotExist")
         addProperty("solr.collection", "authinfo")
       })

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/TestSupportFixture.scala
@@ -63,8 +63,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
       override val bagStore: BagStore = mock[BagStore]
       override lazy val configuration: Configuration = new Configuration("", new PropertiesConfiguration() {
         addProperty("bag-store.url", "http://hostThatDoesNotExist:20110/")
-        addProperty("bag-store.connection-timeout-ms", "600000")
-        addProperty("bag-store.read-timeout-ms", "600000")
+        addProperty("bag-store.connection-timeout-ms", "5000")
+        addProperty("bag-store.read-timeout-ms", "5000")
         addProperty("solr.url", "http://hostThatDoesNotExist")
         addProperty("solr.collection", "authinfo")
       })


### PR DESCRIPTION
Fixes EASY-2137

#### When applied it will
* add configurable timeouts for calls to `easy-bag-store`

@DANS-KNAW/easy for review

See also:
* https://github.com/DANS-KNAW/easy-dtap/pull/366