### PR TITLE
NO JIRA - updated hyperlink in the documentation

### DIFF
--- a/docs/02_to_api.md
+++ b/docs/02_to_api.md
@@ -4,7 +4,7 @@ layout: page
 ---
 
 The API is documented using the [OpenAPI] standard. The API definition files can be downloaded 
-from [`docs/api/`](https://github.com/rkruithof/easy-auth-info/tree/master/docs/api) or
+from [`docs/api/`](https://github.com/DANS-KNAW/easy-auth-info/tree/master/docs/api) or
 <a href="api.html" target="__blank">viewed in Swagger UI in a new tab</a>.
 
 [OpenAPI]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md


### PR DESCRIPTION
NO JIRA

#### When applied it will
* update a hyperlink that was still referring to a fork

#### Where should the reviewer @DANS-KNAW/easy start?

