### PR TITLE
EASY-2393 authCache is not used

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/FileItem.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/FileItem.scala
@@ -28,7 +28,7 @@ import org.json4s.JsonDSL._
 
 import scala.collection.JavaConverters._
 
-case class FileItem(id: UUID, path: Path, owner: String, rights: FileRights, dateAvailable: String) extends DebugEnhancedLogging {
+case class FileItem(id: UUID, path: String, owner: String, rights: FileRights, dateAvailable: String) extends DebugEnhancedLogging {
 
   val solrLiterals: CacheLiterals = Seq(
     ("id", s"$id/$path"),

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/AppSpec.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.authinfo
 
 import java.nio.file.Paths
 
-import nl.knaw.dans.easy.authinfo.components.SolrMocker.expectsSolrDocInCahce
+import nl.knaw.dans.easy.authinfo.components.SolrMocker.expectsSolrDocInCache
 import org.apache.solr.common.SolrDocument
 
 import scala.util.{ Failure, Success }
@@ -45,14 +45,14 @@ class AppSpec extends TestSupportFixture {
   }
 
   it should "succeed with some.txt" in {
-    expectsSolrDocInCahce(new SolrDocument() {
-      addField("id", s"$randomUUID/some.file")
+    expectsSolrDocInCache(new SolrDocument() {
+      addField("id", s"$randomUUID/some%2Efile")
       // ignoring the other fields to avoid testing random order results
       // the full content is tested with ServletSpec (which is designed to manually test all the logging)
     })
     app.jsonRightsOf(Paths.get(s"$randomUUID/some.txt")) shouldBe Success(
       s"""{
-         |  "itemId":"$randomUUID/some.file"
+         |  "itemId":"$randomUUID/some%2Efile"
          |}""".stripMargin
     )
   }

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/ServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/ServletSpec.scala
@@ -60,8 +60,8 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
   }
 
   "get /:uuid/*" should "return values from the solr cache" in {
-    expectsSolrDocInCahce(new SolrDocument() {
-      addField("id", s"$randomUUID/some.file")
+    expectsSolrDocInCache(new SolrDocument() {
+      addField("id", s"$randomUUID/some%2Efile")
       addField("easy_owner", "someone")
       addField("easy_date_available", "1992-07-30")
       addField("easy_accessible_to", "KNOWN")
@@ -69,7 +69,7 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
     })
     get(s"$randomUUID/some.file") {
       // in this case the fields are returned in a random order
-      body should include(s""""itemId":"$randomUUID/some.file"""")
+      body should include(s""""itemId":"$randomUUID/some%2Efile"""")
       body should include(s""""owner":"someone"""")
       body should include(s""""dateAvailable":"1992-07-30"""")
       body should include(s""""accessibleTo":"KNOWN"""")
@@ -86,7 +86,7 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Success(FilesWithAllRightsForKnown)
     shouldReturn(OK_200,
       s"""{
-         |  "itemId":"$randomUUID/path/to/some.file",
+         |  "itemId":"$randomUUID/path/to/some%2Efile",
          |  "owner":"someone",
          |  "dateAvailable":"1992-07-30",
          |  "accessibleTo":"KNOWN",
@@ -104,7 +104,7 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Success(FilesWithAllRightsForKnown)
     shouldReturn(OK_200,
       s"""{
-         |  "itemId":"$randomUUID/some.file",
+         |  "itemId":"$randomUUID/some%2Efile",
          |  "owner":"someone",
          |  "dateAvailable":"1992-07-30",
          |  "accessibleTo":"KNOWN",
@@ -124,13 +124,13 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
   it should "report bag not found" in {
     expectsSolrDocIsNotInCache
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Failure(BagDoesNotExistException(randomUUID))
-    shouldReturn(NOT_FOUND_404, s"$randomUUID/some.file does not exist")
+    shouldReturn(NOT_FOUND_404, s"$randomUUID/some%2Efile does not exist")
   }
 
   it should "report file not found" in {
     expectsSolrDocIsNotInCache
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Success(<files/>)
-    shouldReturn(NOT_FOUND_404, s"$randomUUID/some.file does not exist")
+    shouldReturn(NOT_FOUND_404, s"$randomUUID/some%2Efile does not exist")
   }
 
   it should "report invalid bag: no files.xml" in {

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/components/FileItemSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/components/FileItemSpec.scala
@@ -26,7 +26,7 @@ class FileItemSpec extends TestSupportFixture {
 
   "constructor" should "produce proper json" in {
     val rights = FileRights(KNOWN.toString, ANONYMOUS.toString)
-    val fileItem = FileItem(randomUUID, Paths.get("some/file.txt"), "someone", rights, "1992-07-30")
+    val fileItem = FileItem(randomUUID, "some/file.txt", "someone", rights, "1992-07-30")
     pretty(render(fileItem.json)) shouldBe
       s"""{
          |  "itemId":"$randomUUID/some/file.txt",

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/components/SolrMocker.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/components/SolrMocker.scala
@@ -58,7 +58,7 @@ object SolrMocker extends MockFactory {
     mockDocList.isEmpty _ expects() once() returning true
   }
 
-  def expectsSolrDocInCahce(document: SolrDocument): Any = {
+  def expectsSolrDocInCache(document: SolrDocument): Any = {
     val cachedDoc = new util.Iterator[SolrDocument]() {
 
       override def hasNext: Boolean = true


### PR DESCRIPTION
Fixes EASY-2393

#### When applied it will
* Escape paths of fileItems to be added to authCache
* update logging
* update unit tests accordingly

Where should reviewers from @DANS-KNAW/easy start?
Make calls to the auth-info servlet or CLI and confirm that the caching is used with the correct (escaped) paths.