### PR TITLE
EASY-2393 modified

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -30,14 +30,14 @@ import scala.xml.{ Elem, Node }
 trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with ApplicationWiring {
 
   def rightsOf(bagId: UUID, bagRelativePath: Path): Try[Option[CachedAuthInfo]] = {
-    logger.info(s"[$bagId] retrieving rightsOf item ${bagRelativePath.escapePath}")
+    logger.info(s"[$bagId] retrieving rightsOf file $bagRelativePath")
     authCache.search(s"$bagId/${bagRelativePath.escapePath}") match {
       case Success(Some(doc)) =>
-        logger.info(s"[$bagId] Obtained rightsOf item for ${bagRelativePath.escapePath} from the authCache")
+        logger.info(s"[$bagId] Obtained rightsOf for file $bagRelativePath from the authCache")
         Success(Some(CachedAuthInfo(FileItem.toJson(doc))))
       case Success(None) => fromBagStore(bagId, bagRelativePath)
       case Failure(t) =>
-        logger.warn(s"[$bagId] cache lookup failed for [$bagId/${bagRelativePath.escapePath}] ${ Option(t.getMessage).getOrElse("") }")
+        logger.warn(s"[$bagId] cache lookup failed for file $bagRelativePath ${ Option(t.getMessage).getOrElse("") }")
         fromBagStore(bagId, bagRelativePath)
     }
   }

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -75,14 +75,14 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
       .flatMap {
         case None => Success(None) // TODO cache repeatedly requested but not found bags/files?
         case Some(filesXmlItem) =>
-          collectInfo(bagId, path.escapePath, filesXmlItem).map { fileItem =>
+          collectInfo(bagId, path, filesXmlItem).map { fileItem =>
             val cacheUpdate = authCache.submit(fileItem.solrLiterals)
             Some(CachedAuthInfo(fileItem.json, Some(cacheUpdate)))
           }
       }
   }
 
-  private def collectInfo(bagId: UUID, path: String, fileNode: Node): Try[FileItem] = {
+  private def collectInfo(bagId: UUID, path: Path, fileNode: Node): Try[FileItem] = {
     for {
       ddm <- bagStore.loadDDM(bagId)
       ddmProfile <- getTag(ddm, "profile", bagId)

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -68,7 +68,7 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
   }
 
   private def fromBagStore(bagId: UUID, path: Path): Try[Option[CachedAuthInfo]] = {
-    logger.info(s"[$bagId] item for path ${path.escapePath} not found in authCache, trying to retrieve item from bagStore")
+    logger.info(s"[$bagId] auth-info for file $path not found in authCache, trying to retrieve it from bagStore")
     bagStore
       .loadFilesXML(bagId)
       .map(getFileNode(_, path))

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/FileItem.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/FileItem.scala
@@ -28,7 +28,7 @@ import org.json4s.JsonDSL._
 
 import scala.collection.JavaConverters._
 
-case class FileItem(id: UUID, path: Path, owner: String, rights: FileRights, dateAvailable: String) extends DebugEnhancedLogging {
+case class FileItem(id: UUID, path: String, owner: String, rights: FileRights, dateAvailable: String) extends DebugEnhancedLogging {
 
   val solrLiterals: CacheLiterals = Seq(
     ("id", s"$id/$path"),

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/FileItem.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/FileItem.scala
@@ -27,11 +27,12 @@ import org.json4s.JsonAST.JObject
 import org.json4s.JsonDSL._
 
 import scala.collection.JavaConverters._
+import nl.knaw.dans.lib.encode._
 
-case class FileItem(id: UUID, path: String, owner: String, rights: FileRights, dateAvailable: String) extends DebugEnhancedLogging {
+case class FileItem(id: UUID, path: Path, owner: String, rights: FileRights, dateAvailable: String) extends DebugEnhancedLogging {
 
   val solrLiterals: CacheLiterals = Seq(
-    ("id", s"$id/$path"),
+    ("id", s"$id/${path.escapePath}"),
     ("easy_owner", owner),
     ("easy_date_available", dateAvailable),
     ("easy_accessible_to", rights.accessibleTo.toString),

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/AppSpec.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.authinfo
 
 import java.nio.file.Paths
 
-import nl.knaw.dans.easy.authinfo.components.SolrMocker.expectsSolrDocInCahce
+import nl.knaw.dans.easy.authinfo.components.SolrMocker.expectsSolrDocInCache
 import org.apache.solr.common.SolrDocument
 
 import scala.util.{ Failure, Success }
@@ -45,14 +45,14 @@ class AppSpec extends TestSupportFixture {
   }
 
   it should "succeed with some.txt" in {
-    expectsSolrDocInCahce(new SolrDocument() {
-      addField("id", s"$randomUUID/some.file")
+    expectsSolrDocInCache(new SolrDocument() {
+      addField("id", s"$randomUUID/some%2Efile")
       // ignoring the other fields to avoid testing random order results
       // the full content is tested with ServletSpec (which is designed to manually test all the logging)
     })
     app.jsonRightsOf(Paths.get(s"$randomUUID/some.txt")) shouldBe Success(
       s"""{
-         |  "itemId":"$randomUUID/some.file"
+         |  "itemId":"$randomUUID/some%2Efile"
          |}""".stripMargin
     )
   }

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/ServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/ServletSpec.scala
@@ -60,8 +60,8 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
   }
 
   "get /:uuid/*" should "return values from the solr cache" in {
-    expectsSolrDocInCahce(new SolrDocument() {
-      addField("id", s"$randomUUID/some.file")
+    expectsSolrDocInCache(new SolrDocument() {
+      addField("id", s"$randomUUID/some%2Efile")
       addField("easy_owner", "someone")
       addField("easy_date_available", "1992-07-30")
       addField("easy_accessible_to", "KNOWN")
@@ -69,7 +69,7 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
     })
     get(s"$randomUUID/some.file") {
       // in this case the fields are returned in a random order
-      body should include(s""""itemId":"$randomUUID/some.file"""")
+      body should include(s""""itemId":"$randomUUID/some%2Efile"""")
       body should include(s""""owner":"someone"""")
       body should include(s""""dateAvailable":"1992-07-30"""")
       body should include(s""""accessibleTo":"KNOWN"""")
@@ -86,7 +86,7 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Success(FilesWithAllRightsForKnown)
     shouldReturn(OK_200,
       s"""{
-         |  "itemId":"$randomUUID/path/to/some.file",
+         |  "itemId":"$randomUUID/path/to/some%2Efile",
          |  "owner":"someone",
          |  "dateAvailable":"1992-07-30",
          |  "accessibleTo":"KNOWN",
@@ -104,7 +104,7 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Success(FilesWithAllRightsForKnown)
     shouldReturn(OK_200,
       s"""{
-         |  "itemId":"$randomUUID/some.file",
+         |  "itemId":"$randomUUID/some%2Efile",
          |  "owner":"someone",
          |  "dateAvailable":"1992-07-30",
          |  "accessibleTo":"KNOWN",
@@ -124,13 +124,13 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
   it should "report bag not found" in {
     expectsSolrDocIsNotInCache
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Failure(BagDoesNotExistException(randomUUID))
-    shouldReturn(NOT_FOUND_404, s"$randomUUID/some.file does not exist")
+    shouldReturn(NOT_FOUND_404, s"$randomUUID/some%2Efile does not exist")
   }
 
   it should "report file not found" in {
     expectsSolrDocIsNotInCache
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Success(<files/>)
-    shouldReturn(NOT_FOUND_404, s"$randomUUID/some.file does not exist")
+    shouldReturn(NOT_FOUND_404, s"$randomUUID/some%2Efile does not exist")
   }
 
   it should "report invalid bag: no files.xml" in {

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/components/FileItemSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/components/FileItemSpec.scala
@@ -26,10 +26,10 @@ class FileItemSpec extends TestSupportFixture {
 
   "constructor" should "produce proper json" in {
     val rights = FileRights(KNOWN.toString, ANONYMOUS.toString)
-    val fileItem = FileItem(randomUUID, "some/file.txt", "someone", rights, "1992-07-30")
+    val fileItem = FileItem(randomUUID, Paths.get("some/file.txt"), "someone", rights, "1992-07-30")
     pretty(render(fileItem.json)) shouldBe
       s"""{
-         |  "itemId":"$randomUUID/some/file.txt",
+         |  "itemId":"$randomUUID/some/file%2Etxt",
          |  "owner":"someone",
          |  "dateAvailable":"1992-07-30",
          |  "accessibleTo":"KNOWN",
@@ -39,7 +39,7 @@ class FileItemSpec extends TestSupportFixture {
 
   "toJson" should "convert a SolrDocument without additional solr fields" in {
     val doc = new SolrDocument() {
-      addField("id", s"$randomUUID/some/file.txt")
+      addField("id", s"$randomUUID/some/file%2Etxt")
       addField("easy_owner", "someone")
       addField("easy_date_available", "1992-07-30")
       addField("easy_accessible_to", "KNOWN")
@@ -48,7 +48,7 @@ class FileItemSpec extends TestSupportFixture {
     }
     val expected =
       s"""{
-         |  "itemId":"$randomUUID/some/file.txt",
+         |  "itemId":"$randomUUID/some/file%2Etxt",
          |  "owner":"someone",
          |  "dateAvailable":"1992-07-30",
          |  "accessibleTo":"KNOWN",

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/components/FileItemSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/components/FileItemSpec.scala
@@ -26,7 +26,7 @@ class FileItemSpec extends TestSupportFixture {
 
   "constructor" should "produce proper json" in {
     val rights = FileRights(KNOWN.toString, ANONYMOUS.toString)
-    val fileItem = FileItem(randomUUID, Paths.get("some/file.txt"), "someone", rights, "1992-07-30")
+    val fileItem = FileItem(randomUUID, "some/file.txt", "someone", rights, "1992-07-30")
     pretty(render(fileItem.json)) shouldBe
       s"""{
          |  "itemId":"$randomUUID/some/file.txt",

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/components/SolrMocker.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/components/SolrMocker.scala
@@ -58,7 +58,7 @@ object SolrMocker extends MockFactory {
     mockDocList.isEmpty _ expects() once() returning true
   }
 
-  def expectsSolrDocInCahce(document: SolrDocument): Any = {
+  def expectsSolrDocInCache(document: SolrDocument): Any = {
     val cachedDoc = new util.Iterator[SolrDocument]() {
 
       override def hasNext: Boolean = true


### PR DESCRIPTION
Fixes EASY-2393

Improved @rkruithof's PR. Reverted to replacement of `Path` by `String` (one of the suggestions by @rvanheest). Improved the logging statements a bit. They talked about "items" when referring to authorization info. This may lead to confusion with items from the bag store.

Please, all, use the terminology defined in https://dans-knaw.github.io/easy-bag-store/definitions/.

* **items** are bags, directories and files in the bag store.
* **item-ids** are identifiers to reference those things. Percent-encoding is used in the path components of items that reference files or directories.

#### When applied it will
* replace https://github.com/DANS-KNAW/easy-auth-info/pull/30

#### Where should the reviewer @DANS-KNAW/easy start?

