### PR TITLE
EASY-2451: fix SOLR schema and introduce delete command

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,12 @@ SYNOPSIS
     easy-auth-info delete <solr-query> # Delete the selected item(s) from the SOLR index
     easy-auth-info run-service # Runs the program as a service
 
+    Some examples of standard solr queries for the delete command:
+
+      everything:                        '*'
+      all files of a particular user:    'easy_owner:<name>'
+      all files of a particular dataset: 'id:<bag-id>/*'
+
 
 DESCRIPTION
 -----------

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,9 @@ easy-auth-info
 SYNOPSIS
 --------
 
+    easy-auth-info get <item-id> # Retrieves the information from the cache or directly from the bag-store
+    easy-auth-info delete <solr-query> # Delete the selected item(s) from the SOLR index
     easy-auth-info run-service # Runs the program as a service
-    easy-auth-info <item-id> # Retrieves the information from the cache or directly from the bag-store
 
 
 DESCRIPTION
@@ -18,11 +19,22 @@ Provides consolidated authorization info about items in a bag store.
 ARGUMENTS
 ---------
 
-     -h, --help      Show help message
-     -v, --version   Show version of this program
+      -h, --help      Show help message
+      -v, --version   Show version of this program
+    
+    Subcommand: get - Retrieve the authorization info about the given item in a bagstore
+      -h, --help   Show help message
     
      trailing arguments:
-      path (not required)
+      itemId (required)
+    ---
+    
+    Subcommand: delete - Delete documents from the SOLR index
+      -h, --help   Show help message
+    
+     trailing arguments:
+      solr-query (required)
+    ---
     
     Subcommand: run-service - Starts EASY Auth Info as a daemon that services HTTP requests
       -h, --help   Show help message

--- a/src/main/assembly/dist/cfg/logback-service.xml
+++ b/src/main/assembly/dist/cfg/logback-service.xml
@@ -18,7 +18,7 @@
     </appender>
     <root level="warn">
         <appender-ref ref="FILE"/>
-        <appender-ref ref="JOURNAL" />
+        <appender-ref ref="JOURNAL"/>
     </root>
-    <logger name="nl.knaw.dans.easy" level="info" />
+    <logger name="nl.knaw.dans.easy" level="info"/>
 </configuration>

--- a/src/main/assembly/dist/cfg/logback.xml
+++ b/src/main/assembly/dist/cfg/logback.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-	<appender name="FILE"
-			  class="ch.qos.logback.core.rolling.RollingFileAppender">
-		<file>${user.home}/easy-auth-info.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${user.home}/easy-auth-info.%d{yyyy-MM-dd}.log</fileNamePattern>
-			<maxHistory>30</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>[%date{ISO8601}] %-5level %msg%n</pattern>
-		</encoder>
-	</appender>
-	<root level="warn">
-		<appender-ref ref="FILE" />
-	</root>
-	<logger name="nl.knaw.dans.easy" level="info" />
+    <appender name="FILE"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${user.home}/easy-auth-info.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${user.home}/easy-auth-info.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>[%date{ISO8601}] %-5level %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="warn">
+        <appender-ref ref="FILE"/>
+    </root>
+    <logger name="nl.knaw.dans.easy" level="info"/>
 </configuration>

--- a/src/main/assembly/dist/install/authinfo/schema.xml
+++ b/src/main/assembly/dist/install/authinfo/schema.xml
@@ -151,6 +151,8 @@
     <field name="easy_accessible_to" type="string" indexed="true" stored="true" required="true"/>
     <field name="easy_visible_to" type="string" indexed="true" stored="true" required="true"/>
     <field name="easy_date_available" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
+    <field name="easy_license_key" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
+    <field name="easy_license_title" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
     <!-- End of EASY fields -->
 
     <!-- catchall field, containing all other searchable text fields (implemented

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/Command.scala
@@ -41,6 +41,7 @@ object Command extends App with DebugEnhancedLogging {
     commandLine.subcommand
       .collect {
         case get @ commandLine.get => app.jsonAuthInfo(get.itemId())
+        case delete @ commandLine.delete => app.delete(delete.query())
         case commandLine.runService => runAsService(app)
       }
       .getOrElse(Failure(new IllegalArgumentException(s"Unknown command: ${ commandLine.subcommand }")))

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/CommandLineOptions.scala
@@ -30,7 +30,14 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
     s"""
        |  $printedName get <item-id> # Retrieves the information from the cache or directly from the bag-store
        |  $printedName delete <solr-query> # Delete the selected item(s) from the SOLR index
-       |  $printedName run-service # Runs the program as a service""".stripMargin
+       |  $printedName run-service # Runs the program as a service
+       |
+       |  Some examples of standard solr queries for the delete command:
+       |
+       |    everything:                        '*'
+       |    all files of a particular user:    'easy_owner:<name>'
+       |    all files of a particular dataset: 'id:<bag-id>/*'
+       |""".stripMargin
 
   version(s"$printedName v${ configuration.version }")
   banner(

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/CommandLineOptions.scala
@@ -28,8 +28,9 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val description: String = s"""Provides consolidated authorization info about items in a bag store."""
   val synopsis: String =
     s"""
-       |  $printedName run-service # Runs the program as a service
-       |  $printedName <item-id> # Retrieves the information from the cache or directly from the bag-store""".stripMargin
+       |  $printedName get <item-id> # Retrieves the information from the cache or directly from the bag-store
+       |  $printedName delete <solr-query> # Delete the selected item(s) from the SOLR index
+       |  $printedName run-service # Runs the program as a service""".stripMargin
 
   version(s"$printedName v${ configuration.version }")
   banner(
@@ -43,15 +44,24 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
        |Options:
        |""".stripMargin)
 
-  val path: ScallopOption[Path] = trailArg[Path](name = "path", required = false)
-
-  //noinspection TypeAnnotation
-  val runService = new Subcommand("run-service") {
-    descr(
-      "Starts EASY Auth Info as a daemon that services HTTP requests")
+  val get = new Subcommand("get") {
+    descr("Retrieve the authorization info about the given item in a bagstore")
+    val itemId: ScallopOption[Path] = trailArg[Path](name = "itemId")
     footer(SUBCOMMAND_SEPARATOR)
   }
+  val delete = new Subcommand("delete") {
+    descr("Delete documents from the SOLR index")
+    val query: ScallopOption[String] = trailArg[String](name = "solr-query")
+    footer(SUBCOMMAND_SEPARATOR)
+  }
+  val runService = new Subcommand("run-service") {
+    descr("Starts EASY Auth Info as a daemon that services HTTP requests")
+    footer(SUBCOMMAND_SEPARATOR)
+  }
+  addSubcommand(get)
+  addSubcommand(delete)
   addSubcommand(runService)
 
   footer("")
+  verify()
 }

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -91,7 +91,10 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
         case None => Success(None) // TODO cache repeatedly requested but not found bags/files?
         case Some(filesXmlItem) =>
           collectInfo(bagId, path, filesXmlItem).map { fileItem =>
-            val cacheUpdate = authCache.submit(fileItem.solrLiterals)
+            val cacheUpdate = for {
+              cacheUpdate <- authCache.submit(fileItem.solrLiterals)
+              _ <- authCache.commit()
+            } yield cacheUpdate
             Some(CachedAuthInfo(fileItem.json, Some(cacheUpdate)))
           }
       }

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -49,6 +49,19 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
     case None => Failure(new FileNotFoundException(fullPath.toString))
   }
 
+  def delete(query: String): Try[FeedBackMessage] = {
+    logger.info(s"deleting documents with query '$query'")
+    for {
+      _ <- authCache.delete(query)
+      _ <- authCache.commit()
+    } yield s"Deleted documents with query '$query'"
+  } recoverWith {
+    case t: CacheCommitException => Failure(t)
+    case t =>
+      authCache.commit()
+      Failure(t)
+  }
+
   /** @param fullPath <UUID>/<bag-relative-path> */
   private def authInfo(fullPath: Path): Try[Option[CachedAuthInfo]] = for {
     uuid <- extractUUID(fullPath)

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -19,6 +19,7 @@ import java.io.FileNotFoundException
 import java.nio.file.Path
 import java.util.UUID
 
+import nl.knaw.dans.easy.authinfo.Command.FeedBackMessage
 import nl.knaw.dans.easy.authinfo.components.{ FileItem, FileRights }
 import nl.knaw.dans.lib.encode.PathEncoding
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -105,7 +105,7 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
       .recoverWith { case _ => Failure(InvalidBagException(s"'EASY-User-Account' (case sensitive) not found in $bagId/bag-info.txt")) }
   }
 
-  def getFileNode(xmlDoc: Elem, path: Path): Option[Node] = {
+  private def getFileNode(xmlDoc: Elem, path: Path): Option[Node] = {
     (xmlDoc \ "file").find(_
       .attribute("filepath")
       .map(_.text)

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -86,7 +86,7 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
     for {
       ddm <- bagStore.loadDDM(bagId)
       ddmProfile <- getTag(ddm, "profile", bagId)
-      dcmiMetadata = getOptionalTag(ddm, "dcmiMetadata")
+      dcmiMetadata = (ddm \ "dcmiMetadata").headOption
       dateAvailable <- getTag(ddmProfile, "available", bagId).map(_.text)
       rights <- FileRights.get(ddmProfile, fileNode)
       license <- configuration.licenses.getLicense(dcmiMetadata, rights)
@@ -98,10 +98,6 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
   private def getTag(node: Node, tag: String, bagId: UUID): Try[Node] = {
     Try { (node \ tag).head }
       .recoverWith { case _ => Failure(InvalidBagException(s"<ddm:$tag> not found in $bagId/dataset.xml")) }
-  }
-
-  private def getOptionalTag(node: Node, tag: String): Option[Node] = {
-    (node \ tag).headOption
   }
 
   private def getDepositor(bagInfoMap: BagInfo, bagId: UUID): Try[String] = {

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -44,7 +44,8 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
 
   /** @param fullPath <UUID>/<bag-relative-path> */
   def jsonAuthInfo(fullPath: Path): Try[String] = authInfo(fullPath).flatMap {
-    case Some(CachedAuthInfo(authInfo, _)) => Success(pretty(render(authInfo)))
+    case Some(CachedAuthInfo(authInfo, Some(Success(_)) | None)) => Success(pretty(render(authInfo)))
+    case Some(CachedAuthInfo(_, Some(Failure(e)))) => Failure(e)
     case None => Failure(new FileNotFoundException(fullPath.toString))
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoServlet.scala
@@ -61,10 +61,10 @@ class EasyAuthInfoServlet(app: EasyAuthInfoApp) extends ScalatraServlet
   private def respond(uuid: UUID, path: Path, authInfo: Try[Option[CachedAuthInfo]]): ActionResult = {
     authInfo match {
       case Success(Some(CachedAuthInfo(json, Some(Failure(t))))) =>
-        logger.error(s"cache update failed for [$uuid/${path.escapePath}] reason: ${ t.getMessage.toOneLiner }")
+        logger.error(s"[$uuid] cache update failed for [$uuid/${path.escapePath}] reason: ${ t.getMessage.toOneLiner }")
         Ok(pretty(render(json)))
       case Success(Some(CachedAuthInfo(json, Some(Success(_))))) =>
-        logger.info(s"cache updated for [$uuid/${path.escapePath}]")
+        logger.info(s"[$uuid] cache updated for [$uuid/${path.escapePath}]")
         Ok(pretty(render(json)))
       case Success(Some(CachedAuthInfo(json, _))) =>
         Ok(pretty(render(json)))
@@ -72,11 +72,11 @@ class EasyAuthInfoServlet(app: EasyAuthInfoApp) extends ScalatraServlet
       case Failure(HttpStatusException(message, HttpResponse(_, SERVICE_UNAVAILABLE_503, _))) => ServiceUnavailable(message)
       case Failure(BagDoesNotExistException(uuid: UUID)) => NotFound(s"$uuid/${path.escapePath} does not exist")
       case Failure(t: InvalidBagException) =>
-        logger.error(s"invalid bag: ${ t.getMessage }")
-        InternalServerError("not expected exception")
+        logger.error(s"[$uuid] invalid bag: ${ t.getMessage }")
+        InternalServerError(s"bag $uuid appears to be invalid")
       case Failure(t) =>
-        logger.error(t.getMessage, t)
-        InternalServerError("not expected exception")
+        logger.error(s"[$uuid] unexpected error: ${t.getMessage}", t)
+        InternalServerError("unexpected error")
     }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/AuthCacheNotConfigured.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/AuthCacheNotConfigured.scala
@@ -29,6 +29,8 @@ trait AuthCacheNotConfigured extends AutoCloseable {
 
   def submit(cacheFields: CacheLiterals): Try[UpdateResponse] = notImplemented
 
+  def delete(query: String): Try[UpdateResponse] = notImplemented
+
   def commit(): Try[UpdateResponse] = notImplemented
 
   override def close(): Unit = ()

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/AuthCacheNotConfigured.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/AuthCacheNotConfigured.scala
@@ -21,7 +21,7 @@ import org.apache.solr.common.SolrDocument
 
 import scala.util.{ Failure, Success, Try }
 
-trait AuthCacheNotConfigured {
+trait AuthCacheNotConfigured extends AutoCloseable {
 
   private val notImplemented = Failure(new NotImplementedError("no cache configured, assembling responses from bag store only"))
 
@@ -31,7 +31,7 @@ trait AuthCacheNotConfigured {
 
   def commit(): Try[UpdateResponse] = notImplemented
 
-  def close(): Try[Unit] = Success(())
+  override def close(): Unit = ()
 }
 object AuthCacheNotConfigured {
   type CacheLiterals = Seq[(String, String)]

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/AuthCacheWithSolr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/AuthCacheWithSolr.scala
@@ -57,9 +57,11 @@ trait AuthCacheWithSolr extends AuthCacheNotConfigured with DebugEnhancedLogging
       .recoverWith { case t => Failure(CacheUpdateException(solrFields, t)) }
   }
 
-  override def close(): Try[Unit] = {
+
+  override def close(): Unit = {
+    logger.info(s"closing SOLR cache")
     solrClient.commit() // don't care about a failure, loosing a few pending changes is a minor performance loss
-    Try(solrClient.close())
+    solrClient.close()
   }
 
   private def isParseException(t: HttpSolrClient.RemoteSolrException) = {

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/AuthCacheWithSolr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/AuthCacheWithSolr.scala
@@ -61,7 +61,7 @@ trait AuthCacheWithSolr extends AuthCacheNotConfigured with DebugEnhancedLogging
     val q = new SolrQuery {
       set("q", query)
     }
-    Try { solrClient.deleteByQuery(q.getQuery) }
+    Try { solrClient.deleteByQuery(q.getQuery, commitWithinMs) }
       .flatMap(checkResponseStatus)
       .recoverWith {
         case t: HttpSolrClient.RemoteSolrException if isParseException(t) =>

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/components/AuthCacheWithSolr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/components/AuthCacheWithSolr.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.authinfo.components
 
 import nl.knaw.dans.easy.authinfo.components.AuthCacheNotConfigured.CacheLiterals
-import nl.knaw.dans.easy.authinfo.{ CacheBadRequestException, CacheSearchException, CacheStatusException, CacheUpdateException }
+import nl.knaw.dans.easy.authinfo.{ CacheBadRequestException, CacheDeleteException, CacheSearchException, CacheStatusException, CacheUpdateException }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.http.HttpStatus._
 import org.apache.solr.client.solrj.impl.HttpSolrClient
@@ -57,6 +57,24 @@ trait AuthCacheWithSolr extends AuthCacheNotConfigured with DebugEnhancedLogging
       .recoverWith { case t => Failure(CacheUpdateException(solrFields, t)) }
   }
 
+  override def delete(query: String): Try[UpdateResponse] = {
+    val q = new SolrQuery {
+      set("q", query)
+    }
+    Try { solrClient.deleteByQuery(q.getQuery) }
+      .flatMap(checkResponseStatus)
+      .recoverWith {
+        case t: HttpSolrClient.RemoteSolrException if isParseException(t) =>
+          Failure(CacheBadRequestException(t.getMessage, t))
+        case t =>
+          Failure(CacheDeleteException(query, t))
+      }
+  }
+
+  override def commit(): Try[UpdateResponse] = Try {
+    logger.info("committing document(s) to SOLR cache")
+    solrClient.commit()
+  }
 
   override def close(): Unit = {
     logger.info(s"closing SOLR cache")

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/package.scala
@@ -61,6 +61,9 @@ package object authinfo {
   case class CacheUpdateException(literals: CacheLiterals, cause: Throwable)
     extends Exception(s"solr update of [${ literals.toMap.mkString(", ") }] failed with ${ cause.getMessage }", cause)
 
+  case class CacheDeleteException(query: String, cause: Throwable)
+    extends Exception(s"solr delete [$query] failed with ${ cause.getMessage }", cause)
+
   case class CacheCommitException(cause: Throwable)
     extends Exception(cause.getMessage, cause)
 

--- a/src/test/resources/debug-config/logback-service.xml
+++ b/src/test/resources/debug-config/logback-service.xml
@@ -5,7 +5,7 @@
             <pattern>[%date{ISO8601}] %-5level %msg%n</pattern>
         </encoder>
     </appender>
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>data/easy-auth-info.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>data/easy-auth-info.%d{yyyy-MM-dd}.log</fileNamePattern>
@@ -16,8 +16,8 @@
         </encoder>
     </appender>
     <root level="warn">
-        <appender-ref ref="FILE" />
-        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="nl.knaw.dans.easy" level="trace" />
+    <logger name="nl.knaw.dans.easy" level="trace"/>
 </configuration>

--- a/src/test/resources/debug-config/logback.xml
+++ b/src/test/resources/debug-config/logback.xml
@@ -6,20 +6,20 @@
         </encoder>
     </appender>
 
-	<appender name="FILE"
-			  class="ch.qos.logback.core.FileAppender">
-		<file>data/easy-auth-info.log</file>
+    <appender name="FILE"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>data/easy-auth-info.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>data/easy-auth-info.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
-		<encoder>
-			<pattern>[%date{ISO8601}] %-5level %msg%n</pattern>
-		</encoder>
-	</appender>
-	<root level="warn">
-		<appender-ref ref="FILE"/>
+        <encoder>
+            <pattern>[%date{ISO8601}] %-5level %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="warn">
+        <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
-	</root>
-	<logger name="nl.knaw.dans.easy" level="trace" />
+    </root>
+    <logger name="nl.knaw.dans.easy" level="trace"/>
 </configuration>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -7,12 +7,11 @@
     </appender>
 
     <!-- No logging during the build -->
-    <root level="off" >
-        <appender-ref ref="STDOUT" />
+    <root level="off">
+        <appender-ref ref="STDOUT"/>
     </root>
 
     <!-- Set log level during test with system property, e.g., mvn test -DLOG_LEVEL=debug -->
-    <logger name="nl.knaw.dans.easy" level="${LOG_LEVEL:-off}" />
-    <logger name="org.scalatest" level="info" />
-
+    <logger name="nl.knaw.dans.easy" level="${LOG_LEVEL:-off}"/>
+    <logger name="org.scalatest" level="info"/>
 </configuration>

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/ServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/ServletSpec.scala
@@ -140,28 +140,28 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
   it should "report invalid bag: no files.xml" in {
     expectsSolrDocIsNotInCache
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning httpException(s"File $randomUUID/metadata/files.xml does not exist in BagStore")
-    shouldReturn(INTERNAL_SERVER_ERROR_500, s"not expected exception")
+    shouldReturn(INTERNAL_SERVER_ERROR_500, "unexpected error")
   }
 
   it should "report invalid bag: no DDM" in {
     expectsSolrDocIsNotInCache
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Success(<files><file filepath="some.file"/></files>)
     mockedBagStore.loadDDM _ expects randomUUID once() returning httpException(s"File $randomUUID/metadata/dataset.xml does not exist in BagStore")
-    shouldReturn(INTERNAL_SERVER_ERROR_500, s"not expected exception")
+    shouldReturn(INTERNAL_SERVER_ERROR_500, "unexpected error")
   }
 
   it should "report invalid bag: no profile in DDM" in {
     expectsSolrDocIsNotInCache
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Success(<files><file filepath="some.file"/></files>)
     mockedBagStore.loadDDM _ expects randomUUID once() returning Success(<ddm:DDM/>)
-    shouldReturn(INTERNAL_SERVER_ERROR_500, s"not expected exception")
+    shouldReturn(INTERNAL_SERVER_ERROR_500, s"bag $randomUUID appears to be invalid")
   }
 
   it should "report invalid bag: no date available in DDM" in {
     expectsSolrDocIsNotInCache
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Success(<files><file filepath="some.file"/></files>)
     mockedBagStore.loadDDM _ expects randomUUID once() returning Success(<ddm:DDM><ddm:profile/></ddm:DDM>)
-    shouldReturn(INTERNAL_SERVER_ERROR_500, s"not expected exception")
+    shouldReturn(INTERNAL_SERVER_ERROR_500, s"bag $randomUUID appears to be invalid")
   }
 
   it should "report invalid bag: no bag-info.txt" in {
@@ -169,7 +169,7 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Success(<files><file filepath="some.file"/></files>)
     mockedBagStore.loadDDM _ expects randomUUID once() returning Success(openAccessDDM)
     mockedBagStore.loadBagInfo _ expects randomUUID once() returning httpException(s"File $randomUUID/info.txt does not exist in BagStore")
-    shouldReturn(INTERNAL_SERVER_ERROR_500, s"not expected exception")
+    shouldReturn(INTERNAL_SERVER_ERROR_500, "unexpected error")
   }
 
   it should "report invalid bag: depositor not found" in {
@@ -177,7 +177,7 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
     mockedBagStore.loadBagInfo _ expects randomUUID once() returning Success(Map.empty)
     mockedBagStore.loadDDM _ expects randomUUID once() returning Success(openAccessDDM)
     mockedBagStore.loadFilesXML _ expects randomUUID once() returning Success(<files><file filepath="some.file"/></files>)
-    shouldReturn(INTERNAL_SERVER_ERROR_500, s"not expected exception")
+    shouldReturn(INTERNAL_SERVER_ERROR_500, s"bag $randomUUID appears to be invalid")
   }
 
   private def shouldReturn(expectedStatus: Int, expectedBody: String, whenRequesting: String = s"$randomUUID/some.file"): Any = {


### PR DESCRIPTION
Fixes EASY-2451

#### When applied it will
* fix the SOLR schema after #33 (03bb358)
* refactored the command line interface (095c419)
* introduce a `delete` command for the command line to be able to clear the cache (916e0eb)
* make sure `commit` is always called after `submit` (742dd50)
* fix errors in the logback configuration (d85f702)
* some minor formatting (de77fb9, 34516f3) and rewriting (8a8522c, e277522, 94d5cc2)

@DANS-KNAW/easy for review

#### Notes for deploying
* build and deploy `easy-auth-info` as normal
* ssh into the server as `root` user
* run the following commands (_taken from the LDAP role `easy-solr-search2`, which is not able to be run because there is no version upgrade of SOLR_)
    * `cp /opt/dans.knaw.nl/easy-auth-info/install/authinfo/schema.xml /var/opt/org.apache/solr-home/data/authinfo/conf/`
    * `systemctl restart solr`
