### PR TITLE
GitHub Actions for release-drafts and maven builds

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+change-template: '* $TITLE (#$NUMBER)'
+sort-direction: ascending
+template: |
+  $CHANGES

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,39 @@
+name: Maven CI
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - '.gitignore'
+      - '.travis.yml'
+      - 'debug-init-env.sh'
+      - 'README.md'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - '.gitignore'
+      - '.travis.yml'
+      - 'debug-init-env.sh'
+      - 'README.md'
+
+jobs:
+  build:
+    name: Setting the Ubuntu Environment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: mvn -ntp clean install -DskipTests
+      - name: Run tests with Maven
+        run: mvn -ntp clean test

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5.5.0
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
~Fixes EASY-~

#### When applied it will
* [x] add [release-drafter](https://github.com/release-drafter/release-drafter) configuration
* [x] add a GitHub Action for running Maven builds
* [ ] add a GitHub Action to upload new documentations to the doc-site

@DANS-KNAW/easy for review

For reference, I've been experimenting with these actions in https://github.com/rvanheest/release-drafter-test.
With this we're not gonna need Travis anymore...