### PR TITLE
EASY-2332: validation of UUIDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.scalaj</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -79,10 +79,9 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
 
   /** @param fullPath <UUID>/<bag-relative-path> */
   private def extractUUID(fullPath: Path): Try[UUID] = {
-    Try { fullPath.getName(0).toString } match {
-      case Success(name) => name.toUUID.toTry
-      case t => Failure(new Exception(s"can't extract valid UUID from [$fullPath]"))
-    }
+    Try { fullPath.getName(0).toString }
+      .recoverWith { case e => Failure(new Exception(s"can't extract valid UUID from [$fullPath]", e)) }
+      .flatMap(_.toUUID.toTry)
   }
 
   private def fromBagStore(bagId: UUID, path: Path): Try[Option[CachedAuthInfo]] = {

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -23,6 +23,7 @@ import nl.knaw.dans.easy.authinfo.Command.FeedBackMessage
 import nl.knaw.dans.easy.authinfo.components.{ FileItem, FileRights }
 import nl.knaw.dans.lib.encode.PathEncoding
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.string._
 import org.json4s.native.JsonMethods.{ pretty, render }
 
 import scala.util.{ Failure, Success, Try }
@@ -78,7 +79,7 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
 
   /** @param fullPath <UUID>/<bag-relative-path> */
   private def extractUUID(fullPath: Path): Try[UUID] = {
-    Try(UUID.fromString(fullPath.getName(0).toString))
+    fullPath.getName(0).toString.toUUID.toTry
       .recoverWith { case t => Failure(new Exception(s"can't extract valid UUID from [$fullPath]", t)) }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoApp.scala
@@ -79,8 +79,10 @@ trait EasyAuthInfoApp extends AutoCloseable with DebugEnhancedLogging with Appli
 
   /** @param fullPath <UUID>/<bag-relative-path> */
   private def extractUUID(fullPath: Path): Try[UUID] = {
-    fullPath.getName(0).toString.toUUID.toTry
-      .recoverWith { case t => Failure(new Exception(s"can't extract valid UUID from [$fullPath]", t)) }
+    Try { fullPath.getName(0).toString } match {
+      case Success(name) => name.toUUID.toTry
+      case t => Failure(new Exception(s"can't extract valid UUID from [$fullPath]"))
+    }
   }
 
   private def fromBagStore(bagId: UUID, path: Path): Try[Option[CachedAuthInfo]] = {

--- a/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.authinfo/EasyAuthInfoServlet.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 import nl.knaw.dans.lib.encode.PathEncoding
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.logging.servlet._
+import nl.knaw.dans.lib.string._
 import org.eclipse.jetty.http.HttpStatus._
 import org.json4s.native.JsonMethods.{ pretty, render }
 import org.scalatra._
@@ -50,7 +51,7 @@ class EasyAuthInfoServlet(app: EasyAuthInfoApp) extends ScalatraServlet
   }
 
   private def getUUID: Try[UUID] = {
-    Try { UUID.fromString(params("uuid")) }
+    params("uuid").toUUID.toTry
   }
 
   private def getPath = Try {

--- a/src/test/scala/nl.knaw.dans.easy.authinfo/ServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.authinfo/ServletSpec.scala
@@ -118,7 +118,7 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer with Sc
   }
 
   it should "report invalid uuid" in {
-    shouldReturn(BAD_REQUEST_400, "Invalid UUID string: 1-2-3-4-5-6", whenRequesting = "1-2-3-4-5-6/some.file")
+    shouldReturn(BAD_REQUEST_400, "String '1-2-3-4-5-6' is not a UUID", whenRequesting = "1-2-3-4-5-6/some.file")
   }
 
   it should "report missing path" in {


### PR DESCRIPTION
Fixes EASY-2332

#### When applied it will
* validate `UUIDs` using `dans.lib.string.toUUID` method

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-archive-bag   | [PR#66](https://github.com/DANS-KNAW/easy-archive-bag/pull/66)     | ..
easy-bag-index  | [PR#50](https://github.com/DANS-KNAW/easy-bag-index/pull/50)     | ..
easy-bag-store  | [PR#100](https://github.com/DANS-KNAW/easy-bag-store/pull/100)     | ..
easy-delete-dataset  | [PR#19](https://github.com/DANS-KNAW/easy-delete-dataset/pull/19)     | ..
easy-deposit-api  | [PR#204](https://github.com/DANS-KNAW/easy-deposit-api/pull/204)     | ..
easy-deposit-properties  | [PR#23](https://github.com/DANS-KNAW/easy-deposit-properties/pull/23)     | ..
easy-ingest-flow  | [PR#137](https://github.com/DANS-KNAW/easy-ingest-flow/pull/137)     | ..
easy-solr4files-index  | [PR#54](https://github.com/DANS-KNAW/easy-solr4files-index/pull/54)     | ..
easy-split-multi-deposit  | [PR#146](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/146)     | ..
easy-transform-metadata  | [PR#11](https://github.com/DANS-KNAW/easy-transform-metadata/pull/11)     | ..
easy-validate-dans-bag  | [PR#73](https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/73)     | ..
